### PR TITLE
Do not print add_query_arg directly

### DIFF
--- a/index.php
+++ b/index.php
@@ -476,7 +476,7 @@ function admin_menu_tree_page_view_add_page ( ) {
 		if ($wpml_lang) {
 			$editLink = add_query_arg("lang", $wpml_lang, $editLink);
 		}
-		echo $editLink;
+		echo base64_encode($editLink);
 	} else {
 		// fail, tell js
 		echo "0";

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -339,9 +339,9 @@ jQuery(function($) {
 				//}
 				//return;
 				if (new_win) {
-					window.open(response);
+					window.open(window.atob(response));
 				} else {
-					document.location = response;
+					document.location = window.atob(response);
 				}
 
 			}


### PR DESCRIPTION
Hi Pär,

you may have seen the discussion at https://wordpress.org/support/topic/this-plugin-has-a-worryingly-high-coderisk-rips-score/ already. The problem occurs because the return value of add_query_arg is printed directly and it contains user input, so it is reported as a XSS vulnerability. Since there is a NONCE check the real security risk should be pretty low but I think it is still a good idea to resolve this. As a quick fix I just encode the value with Base64. A cleaner patch would be to return JSON (and very importantly, the json content type) and parse that instead.

Best regards,
Hendrik